### PR TITLE
Optimize render

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,5 @@ pyaml>=19.12.0
 pyinstaller>=3.5
 flask>=1.1.1
 scikit-image>=0.16.2
+waitress>=1.4.3
 git+https://github.com/FZJ-INM1-BDA/pytiff.git@0701f28e5862c26024e8daa34201005b16db4c8f

--- a/src/app.py
+++ b/src/app.py
@@ -79,6 +79,7 @@ def open_input_file():
 def root():
     global G
     global YAML
+    close_tiff()
     G, YAML = reset_globals()
     return app.send_static_file('index.html')
 
@@ -400,7 +401,10 @@ def file_browser():
 def close_tiff():
     print("Closing tiff file")
     if G['tiff'] is not None:
-        G['tiff'].close()
+        try:
+            G['tiff'].close()
+        except Exception as e:
+            print(e)
 
 def open_browser():
     webbrowser.open_new('http://127.0.0.1:' + str(PORT) + '/')

--- a/src/render_png.py
+++ b/src/render_png.py
@@ -11,10 +11,7 @@ import numpy as np
 import pytiff
 import io
 
-def render_tile(input_file, tile_size, num_channels, level, tx, ty, channel_number):
-
-    tiff = pytiff.Tiff(str(input_file), encoding='utf-8')
-
+def render_tile(tiff, tile_size, num_channels, level, tx, ty, channel_number):
     iy = ty * tile_size
     ix = tx * tile_size
     page_base = level * num_channels
@@ -28,7 +25,7 @@ def render_tile(input_file, tile_size, num_channels, level, tx, ty, channel_numb
     img.frombytes(array_buffer, 'raw', "I;16")
 
     img_io = io.BytesIO()
-    img.save(img_io, 'PNG')
+    img.save(img_io, 'PNG', compress_level=1)
     img_io.seek(0)
     return img_io
 

--- a/src/render_png.py
+++ b/src/render_png.py
@@ -11,7 +11,7 @@ import numpy as np
 import pytiff
 import io
 
-def render_tile(tiff, tile_size, num_channels, level, tx, ty, channel_number):
+def render_tile(tiff: pytiff.Tiff, tile_size, num_channels, level, tx, ty, channel_number):
     iy = ty * tile_size
     ix = tx * tile_size
     page_base = level * num_channels
@@ -30,7 +30,7 @@ def render_tile(tiff, tile_size, num_channels, level, tx, ty, channel_number):
     return img_io
 
 
-def render_tiles(input_file, output_dir, tile_size, num_channels):
+def render_tiles(input_file: str, output_dir, tile_size, num_channels):
 
     print('Processing:', str(input_file))
 
@@ -70,6 +70,7 @@ def render_tiles(input_file, output_dir, tile_size, num_channels):
                 img.frombytes(array_buffer, 'raw', "I;16")
 
                 img.save(str(output_path / group_dir / filename))
+
 
 if __name__ == "__main__":
 


### PR DESCRIPTION
- keep tiff file open between requests
- png compression level lowered to 1
- use "waitress" WSGI server (should support both Windows/*nix, whereas gUnicorn supports only Linux)
  
Flask server can still be used with a cmd-line flag --dev (to enable hot loading of changes in development)
