### PR TITLE
fix svs behavior and svs tests

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -172,7 +172,7 @@ class Opener:
                 return max(counts) == 1
 
             small_levels = list(filter(has_one_tile, self.dz.level_tiles))
-            level_count = self.dz.level_count - len(small_levels)
+            level_count = self.dz.level_count - len(small_levels) + 1
 
             return (3, level_count, width, height)
 

--- a/src/test_app.py
+++ b/src/test_app.py
@@ -47,12 +47,12 @@ def test_import_svs(client):
     res = client.post('/api/import', content_type='application/x-www-form-urlencoded', data=form_data)
     assert res.status_code == 200
 
-    _assert_rgb_tile_exists(client, 2, 0, 0, width=555, height=742)
+    _assert_rgb_tile_exists(client, 2, 0, 0, width=555, height=741)
 
     _assert_rgb_tile_exists(client, 1, 0, 0, width=1024, height=1024)
     _assert_rgb_tile_exists(client, 1, 1, 0, width=86, height=1024)
-    _assert_rgb_tile_exists(client, 1, 0, 1, width=1024, height=460)
-    _assert_rgb_tile_exists(client, 1, 1, 1, width=86, height=460)
+    _assert_rgb_tile_exists(client, 1, 0, 1, width=1024, height=459)
+    _assert_rgb_tile_exists(client, 1, 1, 1, width=86, height=459)
 
     _assert_rgb_tile_exists(client, 0, 0, 0, width=1024, height=1024)
     _assert_rgb_tile_exists(client, 0, 1, 0, width=1024, height=1024)


### PR DESCRIPTION
SVS get_shape now correctly measures the number of levels.
SVS test now correctly rounds pixel shapes down conforming with python integer division.

These two changes are unrelated, but both are necessary to ensure the svs tests pass.