### PR TITLE
Add back-end support for floating point images

### DIFF
--- a/src/render_jpg.py
+++ b/src/render_jpg.py
@@ -15,10 +15,10 @@ def composite_channel(target, image, color, range_min, range_max):
     """Render _image_ in pseudocolor and composite into _target_
     Args:
         target: Numpy float32 array containing composition target image
-        image: Numpy uint16 array of image to render and composite
+        image: Numpy array of image to render and composite
         color: Color as r, g, b float array, 0-1
-        range_min: Threshhold range minimum, 0-65535
-        range_max: Threshhold range maximum, 0-65535
+        range_min: Threshold range minimum (in terms of image pixel values)
+        range_max: Threshold range maximum (in terms of image pixel values)
     """
     f_image = (image.astype("float32") - range_min) / (range_max - range_min)
     f_image = f_image.clip(0, 1, out=f_image)

--- a/src/test_render_jpg.py
+++ b/src/test_render_jpg.py
@@ -18,7 +18,7 @@ def test_ome_tif_rendered_output():
         {
             "Group Path": group_dir,
             "Channel Number": ["0", "1", "2"],
-            "High": [65535, 65535, 65535],
+            "High": [1, 2, 4],
             "Low": [0, 0, 0],
             "Color": [[1.0, 0, 0, 1.0], [0, 1.0, 0, 1.0], [0, 0, 1.0, 1.0]],
         }
@@ -35,23 +35,23 @@ def test_ome_tif_rendered_output():
     filename = os.path.join("tmp", group_dir, "1_0_0.jpg")
     img = io.imread(filename)
     assert img.shape == (1024, 1024, 3)
-    _assert_approx_color(img[200][200], [0, 255, 0])
-    _assert_approx_color(img[200][500], [255, 255, 0])
+    _assert_approx_color(img[200][200], [0, 128, 0])
+    _assert_approx_color(img[200][500], [255, 128, 0])
     _assert_approx_color(img[200][800], [255, 0, 0])
-    _assert_approx_color(img[550][350], [0, 255, 255])
-    _assert_approx_color(img[450][500], [255, 255, 255])
-    _assert_approx_color(img[550][700], [255, 0, 255])
-    _assert_approx_color(img[800][500], [0, 0, 255])
+    _assert_approx_color(img[550][350], [0, 128, 64])
+    _assert_approx_color(img[450][500], [255, 128, 64])
+    _assert_approx_color(img[550][700], [255, 0, 64])
+    _assert_approx_color(img[800][500], [0, 0, 64])
 
     filename = os.path.join("tmp", group_dir, "0_0_0.jpg")
     img = io.imread(filename)
     assert img.shape == (1024, 1024, 3)
-    _assert_approx_color(img[700][700], [0, 255, 0])
+    _assert_approx_color(img[700][700], [0, 128, 0])
 
     filename = os.path.join("tmp", group_dir, "0_0_1.jpg")
     img = io.imread(filename)
     assert img.shape == (1024, 1024, 3)
-    _assert_approx_color(img[300][700], [0, 0, 255])
+    _assert_approx_color(img[300][700], [0, 0, 64])
 
     filename = os.path.join("tmp", group_dir, "0_1_0.jpg")
     img = io.imread(filename)
@@ -61,7 +61,7 @@ def test_ome_tif_rendered_output():
     filename = os.path.join("tmp", group_dir, "0_1_1.jpg")
     img = io.imread(filename)
     assert img.shape == (1024, 1024, 3)
-    _assert_approx_color(img[300][200], [0, 0, 255])
+    _assert_approx_color(img[300][200], [0, 0, 64])
 
 
 def _assert_approx_color(expected, actual, margin=1):


### PR DESCRIPTION
This changes the internal representation of the Low/High thresholds to the
same [0, 1]-based range that's stored in the JSON, instead of scaling them
to [0, 65535] as before. These thresholds are scaled to the range of
representable values for integer image types only when calling the rendering
code (they are left unchanged for float image types).

The conversion from float rendered image to uint8 image for JPEG encoding
now includes a rounding step to improve accuracy.