### PR TITLE
Make resource_path construction more robust

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -576,7 +576,8 @@ def resource_path(relative_path):
         # PyInstaller creates a temp folder at _MEIPASS
         base_path = sys._MEIPASS
     except AttributeError:
-        base_path = os.path.abspath(".")
+        # More robust than "." but could break if this .py file moves.
+        base_path = pathlib.Path(__file__).parent.parent
 
     return os.path.join(base_path, relative_path)
 


### PR DESCRIPTION
Making the path relative to the code works regardless of the current
directory. The old solution of `abspath(".")` only works when run from
the top level of the project.