### PR TITLE
Skip rendering when dynamic range is zero

### DIFF
--- a/src/render_jpg.py
+++ b/src/render_jpg.py
@@ -20,6 +20,8 @@ def composite_channel(target, image, color, range_min, range_max):
         range_min: Threshold range minimum (in terms of image pixel values)
         range_max: Threshold range maximum (in terms of image pixel values)
     """
+    if range_min == range_max:
+        return
     f_image = (image.astype("float32") - range_min) / (range_max - range_min)
     f_image = f_image.clip(0, 1, out=f_image)
     for i, component in enumerate(color):


### PR DESCRIPTION
When range_min==range_max, the rendering equation divides by zero and the
resulting scaled channel image is all NaN. This ends up forcing the entire
image to black as the NaNs propagate through the compositing and get turned
into zeros when cast to uint8. This change just skips rendering and
compositing when the dynamic range is zero.