### PR TITLE
default to empty marker and cell links

### DIFF
--- a/minerva-story/index.html
+++ b/minerva-story/index.html
@@ -14,6 +14,8 @@
   <script>
         window.viewer = MinervaStory.default.build_page({
           hideWelcome: true,
+          cellTypeData: [],
+          markerData: [],
           exhibit: "exhibit.json",
           id: "minerva-browser",
           embedded: true


### PR DESCRIPTION
The lists including `cellTypeData` and `markerData` have become out of date. For the time being, I will change the default behavior to provide empty lists for these fields. In the future this should be configurable.