### PR TITLE
Fix threading issues in auto-threshold code

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -20,6 +20,7 @@ dependencies:
   - pandas=1.5.0
   - zarr=2.13.3
   - altair=4.2.0
+  - blas=*=blis  # blis build seems to avoid threading deadlocks
   - pip=22.3
   - pip:
       - openslide-python==1.2.0


### PR DESCRIPTION
Previous implementation deadlocked on Windows. This change fixes that and cleans up the code in general. Now uses ThreadPoolExecutor instead of explicitly launching Threads. Even after the general cleanups I was encountering deadlocks in np.dot on normal numpy arrays in a threaded context -- switching to the "blis" BLAS implementation fixed that (requirements.yml now contains an entry for this).