### PR TITLE
Fix windows build

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -24,4 +24,4 @@ dependencies:
   - pip=22.3
   - pip:
       - openslide-python==1.2.0
-      - pyinstaller==5.13
+      - pyinstaller==6.10

--- a/requirements.yml
+++ b/requirements.yml
@@ -22,6 +22,6 @@ dependencies:
   - altair=4.2.0
   - blas=*=blis  # blis build seems to avoid threading deadlocks
   - pip=22.3
+  - pyinstaller==6.10
   - pip:
       - openslide-python==1.2.0
-      - pyinstaller==6.10

--- a/src/thumbnail.py
+++ b/src/thumbnail.py
@@ -2,11 +2,12 @@ import os
 import json
 import argparse
 import numpy as np
-import skimage as ski
+import skimage.io
+import skimage.util
 
 def linear_blend(images):
     float_images = [
-        (color, ski.img_as_float(i))
+        (color, skimage.util.img_as_float(i))
         for (_, color, i) in images
     ]
     # Use first channel to define output
@@ -19,7 +20,7 @@ def linear_blend(images):
         float_out += float_color * float_image
     # Uint8 output
     out = np.clip(float_out, 0, 1)
-    return ski.img_as_ubyte(out)
+    return skimage.util.img_as_ubyte(out)
 
 def parse_hex_color(hex_color):
     hex_color = hex_color.lstrip('#')
@@ -33,10 +34,10 @@ def load_json(filename):
         return json.load(f)
 
 def load_jpeg(filename):
-    return ski.io.imread(filename)
+    return skimage.io.imread(filename)
 
 def save_jpeg(filename, image):
-    ski.io.imsave(filename, image)
+    skimage.io.imsave(filename, image)
 
 def to_path_zoom(name):
     zoom = name.split('_')[0]


### PR DESCRIPTION
User reported the following error using Windows build v1.20.3

```
ModuleNotFoundError: No module named 'skimage.io'
```

Upgrading to `pyinstaller==6.10` and importing scikit-image submodules seems to fix this issue. For the reference, the new .exe generated was about 80 MB. Here's the conda env spec on my windows machine [minerva-author-spec-file-win-64.txt](https://github.com/user-attachments/files/17387464/minerva-author-spec-file-win-64.txt), note that I've moved pyinstaller into conda install instead of pip.
